### PR TITLE
coverage string data

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -106,7 +106,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     }
 
     if (result && result.coverage) {
-      if (typeof result.coverage === "string") {
+      if (typeof result.coverage === 'string') {
         result.coverage = JSON.parse(result.coverage);
       }
       collector.add(result.coverage);
@@ -115,7 +115,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
 
   this.onSpecComplete = function(browser, result) {
     if (result.coverage) {
-      if (typeof result.coverage === "string") {
+      if (typeof result.coverage === 'string') {
         result.coverage = JSON.parse(result.coverage);
       }
       collectors[browser.id].add(result.coverage);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -106,12 +106,18 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     }
 
     if (result && result.coverage) {
+      if (typeof result.coverage === "string") {
+        result.coverage = JSON.parse(result.coverage);
+      }
       collector.add(result.coverage);
     }
   };
 
   this.onSpecComplete = function(browser, result) {
     if (result.coverage) {
+      if (typeof result.coverage === "string") {
+        result.coverage = JSON.parse(result.coverage);
+      }
       collectors[browser.id].add(result.coverage);
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "karma-coverage",
+  "name": "hbocodelabs-karma-coverage",
   "version": "0.2.6",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/karma-runner/karma-coverage.git"
+    "url": "https://github.com/HBOCodeLabs/karma-coverage.git"
   },
   "keywords": [
     "karma-plugin",
@@ -48,6 +48,7 @@
     "Ron Derksen <ron.derksen@informaat.nl>",
     "Julie <ju.ralph@gmail.com>",
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
-    "Petar Manev <petar.manev2010@gmail.com>"
+    "Petar Manev <petar.manev2010@gmail.com>",
+    "Stephen Styrchak <stephen.styrchak@hbo.com>"
   ]
 }

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -132,6 +132,26 @@ describe 'reporter', ->
       reporter.onBrowserComplete fakeChrome, undefined
       expect(mockAdd).not.to.have.been.called
 
+    it 'collects coverage data', ->
+      result =
+        coverage:
+          "fileA.js": [4, 5, 6]
+          "fileB.js": [3, 4, 5]
+      parsedValue =
+        "fileA.js": [4, 5, 6]
+        "fileB.js": [3, 4, 5]
+      reporter.onBrowserComplete fakeChrome, result
+      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
+
+    it 'parses string results before collecting', ->
+      result =
+        coverage: '{"file1.js":[4, 5, 6],"file2.js":[3, 4, 5]}'
+      parsedValue =
+        "file1.js": [4, 5, 6]
+        "file2.js": [3, 4, 5]
+      reporter.onBrowserComplete fakeChrome, result
+      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
+
     it 'should make reports', ->
       reporter.onRunComplete browsers
       expect(mockMkdir).to.have.been.calledTwice

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -132,7 +132,7 @@ describe 'reporter', ->
       reporter.onBrowserComplete fakeChrome, undefined
       expect(mockAdd).not.to.have.been.called
 
-    it 'collects coverage data', ->
+    it 'collects coverage data on browser complete', ->
       result =
         coverage:
           "fileA.js": [4, 5, 6]
@@ -143,13 +143,33 @@ describe 'reporter', ->
       reporter.onBrowserComplete fakeChrome, result
       expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
 
-    it 'parses string results before collecting', ->
+    it 'parses string results before collecting on browser complete', ->
       result =
         coverage: '{"file1.js":[4, 5, 6],"file2.js":[3, 4, 5]}'
       parsedValue =
         "file1.js": [4, 5, 6]
         "file2.js": [3, 4, 5]
       reporter.onBrowserComplete fakeChrome, result
+      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
+
+    it 'collects coverage data on spec complete', ->
+      result =
+        coverage:
+          "fileA.js": [4, 5, 6]
+          "fileB.js": [3, 4, 5]
+      parsedValue =
+        "fileA.js": [4, 5, 6]
+        "fileB.js": [3, 4, 5]
+      reporter.onSpecComplete fakeChrome, result
+      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
+
+    it 'parses string results before collecting on spec complete', ->
+      result =
+        coverage: '{"file1.js":[4, 5, 6],"file2.js":[3, 4, 5]}'
+      parsedValue =
+        "file1.js": [4, 5, 6]
+        "file2.js": [3, 4, 5]
+      reporter.onSpecComplete fakeChrome, result
       expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
 
     it 'should make reports', ->


### PR DESCRIPTION
# Change Summary

This change corresponds to HBO CodeLabs' custom adapter that stringifies coverage data before passing it to the transport (we do this to avoid out-of-memory situations on some platforms). As a result, the `result.coverage` property can be a stringified JSON object that has to be parsed before it is collected by istanbul.
# Other Details

I've also renamed the npm package and pointed it at this repository. Although I don't plan to publish the npm package, I want to avoid someone mistakenly stomping over the original, or confusing our custom package for the original. The changes to `package.json` are not intended to be merged back to the origin fork.
