### PR TITLE
Remove HBO changes from master

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -106,18 +106,12 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     }
 
     if (result && result.coverage) {
-      if (typeof result.coverage === 'string') {
-        result.coverage = JSON.parse(result.coverage);
-      }
       collector.add(result.coverage);
     }
   };
 
   this.onSpecComplete = function(browser, result) {
     if (result.coverage) {
-      if (typeof result.coverage === 'string') {
-        result.coverage = JSON.parse(result.coverage);
-      }
       collectors[browser.id].add(result.coverage);
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hbocodelabs-karma-coverage",
+  "name": "karma-coverage",
   "version": "0.2.6",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/HBOCodeLabs/karma-coverage.git"
+    "url": "git://github.com/karma-runner/karma-coverage.git"
   },
   "keywords": [
     "karma-plugin",
@@ -48,7 +48,6 @@
     "Ron Derksen <ron.derksen@informaat.nl>",
     "Julie <ju.ralph@gmail.com>",
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
-    "Petar Manev <petar.manev2010@gmail.com>",
-    "Stephen Styrchak <stephen.styrchak@hbo.com>"
+    "Petar Manev <petar.manev2010@gmail.com>"
   ]
 }

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -132,46 +132,6 @@ describe 'reporter', ->
       reporter.onBrowserComplete fakeChrome, undefined
       expect(mockAdd).not.to.have.been.called
 
-    it 'collects coverage data on browser complete', ->
-      result =
-        coverage:
-          "fileA.js": [4, 5, 6]
-          "fileB.js": [3, 4, 5]
-      parsedValue =
-        "fileA.js": [4, 5, 6]
-        "fileB.js": [3, 4, 5]
-      reporter.onBrowserComplete fakeChrome, result
-      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
-
-    it 'parses string results before collecting on browser complete', ->
-      result =
-        coverage: '{"file1.js":[4, 5, 6],"file2.js":[3, 4, 5]}'
-      parsedValue =
-        "file1.js": [4, 5, 6]
-        "file2.js": [3, 4, 5]
-      reporter.onBrowserComplete fakeChrome, result
-      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
-
-    it 'collects coverage data on spec complete', ->
-      result =
-        coverage:
-          "fileA.js": [4, 5, 6]
-          "fileB.js": [3, 4, 5]
-      parsedValue =
-        "fileA.js": [4, 5, 6]
-        "fileB.js": [3, 4, 5]
-      reporter.onSpecComplete fakeChrome, result
-      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
-
-    it 'parses string results before collecting on spec complete', ->
-      result =
-        coverage: '{"file1.js":[4, 5, 6],"file2.js":[3, 4, 5]}'
-      parsedValue =
-        "file1.js": [4, 5, 6]
-        "file2.js": [3, 4, 5]
-      reporter.onSpecComplete fakeChrome, result
-      expect(mockAdd.lastCall.args[0]).to.deep.equal parsedValue
-
     it 'should make reports', ->
       reporter.onRunComplete browsers
       expect(mockMkdir).to.have.been.calledTwice


### PR DESCRIPTION
## GOAL

Revert any HBO-specific from the master branch, making it more intuitive to reason about upgrading to latest from upstream.

## CHANGES

This PR reverts the previous change to master.  A new branch, `hbo/master`, has already been pushed containing the original commit, and that branch reverts this revert.  This is just an organizational change.
