### PR TITLE
Listening for 'coverage' socket messages and writing coverage data

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -209,7 +209,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
   }
 
   function addCoverageForBrowser (id, coverage) {
-    if (id !== undefined && coverage !== undefined) {
+    if (id  && coverage) {
       var collector = collectors[id];
       if (collector) {
         if (typeof coverage === 'string') {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -208,6 +208,8 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
     return path.join(dir, subdir)
   }
 
+  // Helper for adding coverage for a given browser id, and coverage object
+  // Does not add coverage if no collector was found, or if coverage is not defined
   function addCoverageForBrowser (id, coverage) {
     if (id  && coverage) {
       var collector = collectors[id];
@@ -228,6 +230,8 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
       browsers.forEach(this.onBrowserStart.bind(this))
     }
 
+    // Use the executor to get access to the underlying socket connections to listen for coverage.
+    // we use these for sending the coverage information outside the scope of a test or run.
     executor.socketIoSockets.on('connection', function (socket) {
       socket.on('coverage', function(info) {
         addCoverageForBrowser(info.id, info.coverage);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -28,7 +28,7 @@ function isAbsolute (file) {
 }
 
 // TODO(vojta): inject only what required (config.basePath, config.coverageReporter)
-var CoverageReporter = function (rootConfig, helper, logger, emitter) {
+var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) {
   var log = logger.create('coverage')
 
   // Instance variables
@@ -208,6 +208,18 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
     return path.join(dir, subdir)
   }
 
+  function addCoverageForBrowser (id, coverage) {
+    if (id !== undefined && coverage !== undefined) {
+      var collector = collectors[id];
+      if (collector) {
+        if (typeof coverage === 'string') {
+          coverage = JSON.parse(coverage);
+        }
+        collector.add(coverage);
+      }
+    }
+  }
+
   this.onRunStart = function (browsers) {
     collectors = Object.create(null)
 
@@ -215,6 +227,12 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
     if (browsers) {
       browsers.forEach(this.onBrowserStart.bind(this))
     }
+
+    executor.socketIoSockets.on('connection', function (socket) {
+      socket.on('coverage', function(info) {
+        addCoverageForBrowser(info.id, info.coverage);
+      });
+    });
   }
 
   this.onBrowserStart = function (browser) {
@@ -226,26 +244,15 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   }
 
   this.onBrowserComplete = function (browser, result) {
-    var collector = collectors[browser.id]
+    if (!result) return
 
-    if (!collector) return
-    if (!result || !result.coverage) return
-
-    if (typeof result.coverage === 'string') {
-      result.coverage = JSON.parse(result.coverage);
-    }
-
-    collector.add(result.coverage)
+    addCoverageForBrowser(browser.id, result.coverage);
   }
 
   this.onSpecComplete = function (browser, result) {
-    if (!result.coverage) return
+    if (!result) return
 
-    if (typeof result.coverage === 'string') {
-      result.coverage = JSON.parse(result.coverage);
-    }
-
-    collectors[browser.id].add(result.coverage)
+    addCoverageForBrowser(browser.id, result.coverage);
   }
 
   this.onRunComplete = function (browsers, results) {
@@ -324,7 +331,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   }
 }
 
-CoverageReporter.$inject = ['config', 'helper', 'logger', 'emitter']
+CoverageReporter.$inject = ['config', 'helper', 'logger', 'emitter', 'executor']
 
 // PUBLISH
 module.exports = CoverageReporter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbocodelabs-karma-coverage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## CHANGE SUMMARY
This adds the ability for the clients connected to send a 'coverage' socket io message back that contains the karma id + partial coverage data.  This coverage data will be included in the coverage report.

This means there is a total of 3 ways to get coverage:
1) per spec result (spec completed)
2) per complete result (tests completed)
3) with 'coverage' message

## DETAILS
I needed to use the DI to get a hold of the executor, and use that to get raw access to the sockets.  If anyone knows of a better way to do it, please let me know.  This uses the raw sockets to then listen for certain 'coverage' messages and writes that data out.

## REVIEWERS
- @HBOCodeLabs/uxp 
- @elliot-nelson 
