### PR TITLE
New protocol for client ack's to determine test result/coverage completion

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,6 +55,8 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
 
   var collectors
   var pendingFileWritings = 0
+  var specResults = 0
+  var coverageResults = 0
   var fileWritingFinished = function () {}
 
   function writeReport (reporter, collector) {
@@ -234,7 +236,16 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
     // we use these for sending the coverage information outside the scope of a test or run.
     executor.socketIoSockets.on('connection', function (socket) {
       socket.on('coverage', function(info) {
+        coverageResults++;
         addCoverageForBrowser(info.id, info.coverage);
+      });
+      socket.on('pingresults', function(info, ack) {
+        if (ack !== undefined) {
+          ack({
+            specResults: specResults,
+            coverageResults: coverageResults
+          });
+        }
       });
     });
   }
@@ -256,6 +267,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
   this.onSpecComplete = function (browser, result) {
     if (!result) return
 
+    specResults++;
     addCoverageForBrowser(browser.id, result.coverage);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbocodelabs-karma-coverage",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -176,7 +176,7 @@ describe 'reporter', ->
         coverageResults: 0
       }
       spy1 = sinon.spy()
-      expect(triggerSocketCoverage).toBeDefined
+      expect(triggerPingResults).toBeDefined
       triggerPingResults(undefined, spy1);
       expect(spy1.lastCall.args[0]).to.deep.equal ack
 

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -99,6 +99,7 @@ describe 'reporter', ->
     rootConfig = emitter = executor = reporter = null
     browsers = fakeChrome = fakeOpera = null
     triggerSocketCoverage = null
+    triggerPingResults = null
     mockLogger = create: (name) ->
       debug: -> null
       info: -> null
@@ -115,7 +116,10 @@ describe 'reporter', ->
           on: (name, fn) ->
             fn({
               on: (name, trigger) ->
-                triggerSocketCoverage = trigger
+                if name is 'coverage'
+                  triggerSocketCoverage = trigger
+                else if name is 'pingresults'
+                  triggerPingResults = trigger
             });
         }
       }
@@ -165,6 +169,16 @@ describe 'reporter', ->
       expect(triggerSocketCoverage).toBeDefined
       triggerSocketCoverage(info)
       expect(mockAdd.lastCall.args[0]).to.deep.equal info.coverage
+
+    it 'sends ack with pingresults message', ->
+      ack = {
+        specResults: 0,
+        coverageResults: 0
+      }
+      spy1 = sinon.spy()
+      expect(triggerSocketCoverage).toBeDefined
+      triggerPingResults(undefined, spy1);
+      expect(spy1.lastCall.args[0]).to.deep.equal ack
 
     it 'parses string results before collecting on browser complete', ->
       result =


### PR DESCRIPTION
### CHANGE SUMMARY
Previous PR added capability to open a new client channel and listen for raw socket messages for coverage.  This PR builds on top of this to add a client message for 'pingresults' that also adds client 'ack' such that we send back an acknowledgment to the client containing the number of tests and coverages that we received. Using this information, the client can ensure they wait until the server got all spec results and coverage results before sending a complete event.

### DETAILS
- 'pingresults' message handler
- Counter for number of specs and coverage messages received
- Spec updates 