### PR TITLE
Client request/response for completion status

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,8 +55,9 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
 
   var collectors
   var pendingFileWritings = 0
-  var specResults = 0
-  var coverageResults = 0
+  var browserResults = {};
+  var expectedResults = {};
+  var browserSockets = {};
   var fileWritingFinished = function () {}
 
   function writeReport (reporter, collector) {
@@ -213,7 +214,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
   // Helper for adding coverage for a given browser id, and coverage object
   // Does not add coverage if no collector was found, or if coverage is not defined
   function addCoverageForBrowser (id, coverage) {
-    if (id  && coverage) {
+    if (id && coverage) {
       var collector = collectors[id];
       if (collector) {
         if (typeof coverage === 'string') {
@@ -221,6 +222,27 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
         }
         collector.add(coverage);
       }
+    }
+  }
+
+  function addCountForBrowser (id, type) {
+    if (id && browserResults[id]) {
+      browserResults[id][type]++;
+    }
+  }
+
+  function checkCompletionForBrowser (id) {
+    var results = browserResults[id];
+    var expected = expectedResults[id];
+    var socket = browserSockets[id];
+
+    if (socket && results && expected &&
+      results.specResults === expected.specResults &&
+      results.coverageResults === expected.coverageResults) {
+      socket.emit('completedone', {
+        specResults: results.specResults,
+        coverageResults: results.coverageResults
+      });
     }
   }
 
@@ -236,15 +258,20 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
     // we use these for sending the coverage information outside the scope of a test or run.
     executor.socketIoSockets.on('connection', function (socket) {
       socket.on('coverage', function(info) {
-        coverageResults++;
-        addCoverageForBrowser(info.id, info.coverage);
+        if (info) {
+          addCountForBrowser(info.id, "coverageResults");
+          addCoverageForBrowser(info.id, info.coverage);
+          checkCompletionForBrowser(info.id);
+        }
       });
-      socket.on('pingresults', function(info, ack) {
-        if (ack !== undefined) {
-          ack({
-            specResults: specResults,
-            coverageResults: coverageResults
-          });
+      socket.on('completecheck', function(info) {
+        if (info) {
+          browserSockets[info.id] = socket;
+          expectedResults[info.id] = {
+            specResults: parseInt(info.specResults),
+            coverageResults: parseInt(info.coverageResults)
+          };
+          checkCompletionForBrowser(info.id);
         }
       });
     });
@@ -252,6 +279,10 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
 
   this.onBrowserStart = function (browser) {
     collectors[browser.id] = new istanbul.Collector()
+    browserResults[browser.id] = {
+      specResults: 0,
+      coverageResults: 0
+    };
 
     if (!includeAllSources) return
 
@@ -266,9 +297,9 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
 
   this.onSpecComplete = function (browser, result) {
     if (!result) return
-
-    specResults++;
+    addCountForBrowser(browser.id, "specResults");
     addCoverageForBrowser(browser.id, result.coverage);
+    checkCompletionForBrowser(browser.id);
   }
 
   this.onRunComplete = function (browsers, results) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,6 +55,8 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
 
   var collectors
   var pendingFileWritings = 0
+  var specResults = 0
+  var coverageResults = 0
   var fileWritingFinished = function () {}
 
   function writeReport (reporter, collector) {
@@ -234,7 +236,16 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
     // we use these for sending the coverage information outside the scope of a test or run.
     executor.socketIoSockets.on('connection', function (socket) {
       socket.on('coverage', function(info) {
+        coverageResults++;
         addCoverageForBrowser(info.id, info.coverage);
+      });
+      socket.on('pingresults', function(info, ack) {
+        if (ack !== undefined) {
+          ack({
+            specResults: specResults,
+            coverageResults: coverageResults
+          });
+        }
       });
     });
   }
@@ -256,6 +267,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter, executor) 
   this.onSpecComplete = function (browser, result) {
     if (!result) return
 
+    specResults++;
     addCoverageForBrowser(browser.id, result.coverage);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbocodelabs-karma-coverage",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -176,7 +176,7 @@ describe 'reporter', ->
         coverageResults: 0
       }
       spy1 = sinon.spy()
-      expect(triggerSocketCoverage).toBeDefined
+      expect(triggerPingResults).toBeDefined
       triggerPingResults(undefined, spy1);
       expect(spy1.lastCall.args[0]).to.deep.equal ack
 

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -99,6 +99,7 @@ describe 'reporter', ->
     rootConfig = emitter = executor = reporter = null
     browsers = fakeChrome = fakeOpera = null
     triggerSocketCoverage = null
+    triggerPingResults = null
     mockLogger = create: (name) ->
       debug: -> null
       info: -> null
@@ -115,7 +116,10 @@ describe 'reporter', ->
           on: (name, fn) ->
             fn({
               on: (name, trigger) ->
-                triggerSocketCoverage = trigger
+                if name is 'coverage'
+                  triggerSocketCoverage = trigger
+                else if name is 'pingresults'
+                  triggerPingResults = trigger
             });
         }
       }
@@ -165,6 +169,16 @@ describe 'reporter', ->
       expect(triggerSocketCoverage).toBeDefined
       triggerSocketCoverage(info)
       expect(mockAdd.lastCall.args[0]).to.deep.equal info.coverage
+
+    it 'sends ack with pingresults message', ->
+      ack = {
+        specResults: 0,
+        coverageResults: 0
+      }
+      spy1 = sinon.spy()
+      expect(triggerSocketCoverage).toBeDefined
+      triggerPingResults(undefined, spy1);
+      expect(spy1.lastCall.args[0]).to.deep.equal ack
 
     it 'parses string results before collecting on browser complete', ->
       result =


### PR DESCRIPTION
### CHANGE SUMMARY
Today it is possible that the client sends a complete event that gets handled by the server out of order from the results/coverage responses. This means the run will 'finish' and results are recorded prior to receiving all of the spec results.  This is one cause of instabilities on certain platforms.

To address this, this PR adds a 'completecheck' request from the client that the karma-coverage module listens for.  Once it gets this, it contains the number of spec/coverages that it expects and will notify the client it has received them all with a 'completedone' emit message. The client is able to use this to wait until the server got and handled all messages prior to sending a complete event.

For client side changes to handle this new reporter, see PR https://github.com/HBOCodeLabs/Hadron/pull/10473.

### CHANGES
- Use existing socket hooks (used in previous PR for coverage) to listen/send new messages related to completion
-  Track per-browser spec and coverage counts
- Upon expected spec/coverage counts emits message to client indicating completion
- Updated package version which will get used in Hadron https://github.com/HBOCodeLabs/Hadron/pull/10473